### PR TITLE
Wait for all writers/readers to be created before processing completeAfter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ project ('shared') {
         compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
         compile group: 'com.google.code.findbugs', name: 'annotations', version: findbugsVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
+        testCompile project(':test:testcommon')
     }
     javadoc {
         exclude 'io/pravega/shared/*'

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -50,12 +50,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class ConnectionFactoryImpl implements ConnectionFactory {
 
+    private static final Integer POOL_SIZE = Integer.valueOf(
+            System.getProperty("pravega.client.internal.threadpool.size",
+                    String.valueOf(Runtime.getRuntime().availableProcessors())));
     private final boolean ssl;
     private EventLoopGroup group;
     private boolean nio = false;
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(
-            Runtime.getRuntime().availableProcessors(),
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(POOL_SIZE,
             new ThreadFactoryBuilder().setNameFormat("clientInternal-%d").build());
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -335,7 +335,7 @@ public class DurableLog extends AbstractService implements OperationLog {
             }
         } catch (Exception ex) {
             // Both the inner try and finally blocks above can throw, so we need to catch both of those cases here.
-            log.error("{} Recovery FAILED. {}", this.traceObjectId, ex);
+            log.error("{} Recovery FAILED.", this.traceObjectId, ex);
             throw new CompletionException(ex);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MergeTransactionOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MergeTransactionOperation.java
@@ -133,7 +133,7 @@ public class MergeTransactionOperation extends StorageOperation {
     @Override
     public String toString() {
         return String.format(
-                "%s, StreamSegmentId = %d, Length = %s, ParentOffset = %s",
+                "%s, TransactionSegmentId = %d, Length = %s, ParentOffset = %s",
                 super.toString(),
                 getTransactionSegmentId(),
                 toString(getLength(), -1),

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
@@ -579,6 +579,7 @@ public class StreamSegmentContainerMetadataTests {
         // Attempt to cleanup the eviction candidates, and even throw in a new truncation (to verify that alone won't trigger the cleanup).
         m.removeTruncationMarkers(touchedSeqNo + 1);
         Collection<SegmentMetadata> evictedSegments = m.cleanup(evictionCandidates, maxLastUsed);
+        verifyMetadataConsistency(m);
         for (SegmentMetadata sm : evictedSegments) {
             Assert.assertFalse("Evicted segment was not marked as inactive.", sm.isActive());
         }
@@ -598,6 +599,7 @@ public class StreamSegmentContainerMetadataTests {
         // Now expire the remaining segments and verify.
         evictionCandidates = m.getEvictionCandidates(touchedSeqNo + 1, Integer.MAX_VALUE);
         evictedSegments = m.cleanup(evictionCandidates, touchedSeqNo + 1);
+        verifyMetadataConsistency(m);
         for (SegmentMetadata sm : evictedSegments) {
             Assert.assertFalse("Evicted segment was not marked as inactive.", sm.isActive());
         }
@@ -606,6 +608,56 @@ public class StreamSegmentContainerMetadataTests {
                 touchedSegments.size(), evictedSegments.size());
         for (long segmentId : segments) {
             Assert.assertNull("Candidate segment was not evicted (lookup by id)", m.getStreamSegmentMetadata(segmentId));
+        }
+    }
+
+    /**
+     * Tests the ability to evict Segment Metadata instances that are not in use anymore, subject to a cap. This test
+     * focuses in particular to the case when a segment and all its transactions are eligible for removal, however due
+     * to the cap, some transactions are no longer eligible, and thus the parent segment must not be evicted either.
+     */
+    @Test
+    public void testCleanupCapped() {
+        final int maxCap = 5;
+        final int txnCount = maxCap * 2 + 1;
+        // Expire each Segment at a different stage.
+        final StreamSegmentContainerMetadata m = new MetadataBuilder(CONTAINER_ID).buildAs();
+
+        // Create a single parent segment, followed by a number of transactions. Each segment has a 'LastUsed' set in
+        // incremental order, with the Parent Segment being the least recently used.
+        long maxLastUsed = 1;
+        val segments = new ArrayList<Long>();
+        final long parentSegmentId = segments.size();
+        segments.add(parentSegmentId);
+        m.mapStreamSegmentId(getName(parentSegmentId), parentSegmentId)
+         .setLastUsed(maxLastUsed++);
+
+        for (int i = 0; i < txnCount; i++) {
+            final long transactionId = segments.size();
+            segments.add(transactionId);
+            m.mapStreamSegmentId("Transaction_" + transactionId, transactionId, parentSegmentId)
+             .setLastUsed(maxLastUsed++);
+        }
+
+        // Collect a number of eviction candidates using a stringent max cap (less than the number of segments),
+        // then evict those segments.
+        m.removeTruncationMarkers(maxLastUsed);
+        val evictionCandidates = m.getEvictionCandidates(maxLastUsed, maxCap);
+        val evictedSegments = m.cleanup(evictionCandidates, maxLastUsed);
+        AssertExtensions.assertGreaterThan("At least one segment was expected to be evicted.", 0, evictedSegments.size());
+
+        // Validate ContainerMetadata integrity.
+        verifyMetadataConsistency(m);
+        Assert.assertNotNull("Not expecting the parent Segment to be evicted.", m.getStreamSegmentMetadata(parentSegmentId));
+    }
+
+    private void verifyMetadataConsistency(ContainerMetadata m) {
+        for (Long segmentId : m.getAllStreamSegmentIds()) {
+            val sm = m.getStreamSegmentMetadata(segmentId);
+            if (sm.isTransaction()) {
+                Assert.assertNotNull("Found orphaned Transaction Metadata pointing to parent id " + sm.getParentId(),
+                        m.getStreamSegmentMetadata(sm.getParentId()));
+            }
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -1409,7 +1409,7 @@ public class DurableLogTests extends OperationLogTestBase {
 
     //endregion
 
-    // CorruptedDurableLog
+    //region CorruptedDurableLog
 
     private static class CorruptedDurableLog extends DurableLog {
         private static final AtomicInteger FAIL_AT_INDEX = new AtomicInteger();

--- a/shared/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/src/main/java/io/pravega/shared/NameUtils.java
@@ -54,7 +54,7 @@ public class NameUtils {
      */
     public static String validateUserStreamName(String name) {
         Preconditions.checkNotNull(name);
-        Preconditions.checkArgument(name.matches("[a-zA-Z0-9]+"), "Name must be [a-zA-Z0-9]+");
+        Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
         return name;
     }
 
@@ -68,7 +68,7 @@ public class NameUtils {
         Preconditions.checkNotNull(name);
 
         // In addition to user stream names, pravega internally created stream have a special prefix.
-        final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[a-zA-Z0-9]+";
+        final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[\\p{Alnum}\\.\\-]+";
         Preconditions.checkArgument(name.matches(matcher), "Name must be " + matcher);
         return name;
     }

--- a/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.shared;
 
+import io.pravega.test.common.AssertExtensions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,167 +25,47 @@ public class NameUtilsTest {
 
     @Test
     public void testUserStreamNameVerifier() {
-        try {
-            NameUtils.validateUserStreamName("stream123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            NameUtils.validateUserStreamName("_stream");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateUserStreamName(null);
-            Assert.fail();
-        } catch (NullPointerException e) {
-            // expected
-        }
-        
-        try {
-            NameUtils.validateUserStreamName("a-b-c");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-        
-        try {
-            NameUtils.validateUserStreamName("1.2.3");
-        } catch (Exception e) {
-            Assert.fail();
-        }
+        NameUtils.validateUserStreamName("stream123");
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateUserStreamName("_stream"));
+        AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateUserStreamName(null));
+        NameUtils.validateUserStreamName("a-b-c");
+        NameUtils.validateUserStreamName("1.2.3");
     }
 
     @Test
     public void testStreamNameVerifier() {
-        try {
-            NameUtils.validateStreamName("_systemstream123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            NameUtils.validateStreamName("stream123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            NameUtils.validateStreamName("system_stream123");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateStreamName("stream/123");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateStreamName(null);
-            Assert.fail();
-        } catch (NullPointerException e) {
-            // expected
-        }
-        
-        try {
-            NameUtils.validateUserStreamName("a-b-c");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-        
-        try {
-            NameUtils.validateUserStreamName("1.2.3");
-        } catch (Exception e) {
-            Assert.fail();
-        }
+        NameUtils.validateStreamName("_systemstream123");
+        NameUtils.validateStreamName("stream123");
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName("system_stream123"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName("stream/123"));
+        AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateStreamName(null));
+        NameUtils.validateStreamName("a-b-c");
+        NameUtils.validateStreamName("1.2.3");
     }
 
     @Test
     public void testUserScopeNameVerifier() {
-        try {
-            NameUtils.validateUserScopeName("stream123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            NameUtils.validateUserScopeName("_stream");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateUserScopeName(null);
-            Assert.fail();
-        } catch (NullPointerException e) {
-            // expected
-        }
+        NameUtils.validateUserScopeName("stream123");
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateUserScopeName("_stream"));
+        AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateUserScopeName(null));
     }
 
     @Test
     public void testScopeNameVerifier() {
-        try {
-            NameUtils.validateScopeName("_systemscope123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
 
-        try {
-            NameUtils.validateScopeName("userscope123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
+        NameUtils.validateScopeName("_systemscope123");
+        NameUtils.validateScopeName("userscope123");
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system_scope"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system/scope"));
+        AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateScopeName(null));
 
-        try {
-            NameUtils.validateScopeName("system_scope");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateScopeName("system/scope");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateScopeName(null);
-            Assert.fail();
-        } catch (NullPointerException e) {
-            // expected
-        }
     }
 
     @Test
     public void testReaderGroupNameVerifier() {
-        try {
-            NameUtils.validateReaderGroupName("stream123");
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            NameUtils.validateReaderGroupName("_stream");
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NameUtils.validateReaderGroupName(null);
-            Assert.fail();
-        } catch (NullPointerException e) {
-            // expected
-        }
+        NameUtils.validateReaderGroupName("stream123");
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateReaderGroupName("_stream"));
+        AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateReaderGroupName(null));
     }
 
     @Test

--- a/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -43,6 +43,18 @@ public class NameUtilsTest {
         } catch (NullPointerException e) {
             // expected
         }
+        
+        try {
+            NameUtils.validateUserStreamName("a-b-c");
+        } catch (Exception e) {
+            Assert.fail();
+        }
+        
+        try {
+            NameUtils.validateUserStreamName("1.2.3");
+        } catch (Exception e) {
+            Assert.fail();
+        }
     }
 
     @Test
@@ -78,6 +90,18 @@ public class NameUtilsTest {
             Assert.fail();
         } catch (NullPointerException e) {
             // expected
+        }
+        
+        try {
+            NameUtils.validateUserStreamName("a-b-c");
+        } catch (Exception e) {
+            Assert.fail();
+        }
+        
+        try {
+            NameUtils.validateUserStreamName("1.2.3");
+        } catch (Exception e) {
+            Assert.fail();
         }
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -1,13 +1,12 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -343,7 +343,7 @@ abstract class AbstractFailoverTests {
         }
     }
 
-    void stopReaders(ReaderGroupManager readerGroupManager, String readerGroupName) {
+    void stopReaders() {
         //Stop Readers
         log.info("Stop read flag status {}", testState.stopReadFlag);
         testState.stopReadFlag.set(true);

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -83,7 +83,6 @@ abstract class AbstractFailoverTests {
         final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
-        final AtomicBoolean autoScaleTestFlag = new AtomicBoolean(true);
     }
 
     void performFailoverTest() {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -260,11 +260,13 @@ abstract class AbstractFailoverTests {
                 FutureHelpers.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
                 writerFutureList.add(writerFuture);
             }
-        });
-        FutureHelpers.completeAfter(() -> FutureHelpers.allOf(writerFutureList), testState.writersListComplete.get(0));
-        FutureHelpers.exceptionListener(testState.writersComplete,
-                                        t -> log.error("Exception while waiting for writers to complete", t));
+        }).thenRun(() -> {
+            FutureHelpers.completeAfter(() -> FutureHelpers.allOf(writerFutureList),
+                    testState.writersListComplete.get(0));
+            FutureHelpers.exceptionListener(testState.writersComplete,
+                    t -> log.error("Exception while waiting for writers to complete", t));
 
+        });
     }
 
     void createReaders(ClientFactory clientFactory, String readerGroupName, String scope,
@@ -293,10 +295,11 @@ abstract class AbstractFailoverTests {
                 FutureHelpers.exceptionListener(readerFuture, t -> log.error("Error while reading events:", t));
                 readerFutureList.add(readerFuture);
             }
+        }).thenRun(() -> {
+            FutureHelpers.completeAfter(() -> FutureHelpers.allOf(readerFutureList), testState.readersComplete);
+            FutureHelpers.exceptionListener(testState.readersComplete,
+                    t -> log.error("Exception while waiting for all readers to complete", t));
         });
-        FutureHelpers.completeAfter(() -> FutureHelpers.allOf(readerFutureList), testState.readersComplete);
-        FutureHelpers.exceptionListener(testState.readersComplete,
-                                        t -> log.error("Exception while waiting for all readers to complete", t));
     }
 
     void addNewWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.test.system;
 
+import com.google.common.base.Preconditions;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
@@ -80,6 +81,7 @@ abstract class AbstractFailoverTests {
         final AtomicReference<Throwable> getWriteException = new AtomicReference<>();
         final AtomicReference<Throwable> getReadException =  new AtomicReference<>();
         final AtomicInteger currentNumOfSegments = new AtomicInteger(0);
+        final List<CompletableFuture<Void>> writersListComplete = new ArrayList<>();
         final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
@@ -240,6 +242,7 @@ abstract class AbstractFailoverTests {
     }
 
     void createWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {
+        Preconditions.checkNotNull(testState.writersListComplete.get(0));
         log.info("Client factory details {}", clientFactory.toString());
         log.info("Creating {} writers", writers);
         List<EventStreamWriter<Long>> writerList = new ArrayList<>(writers);
@@ -258,7 +261,7 @@ abstract class AbstractFailoverTests {
                 writerFutureList.add(writerFuture);
             }
         });
-        FutureHelpers.completeAfter(() -> FutureHelpers.allOf(writerFutureList), testState.writersComplete);
+        FutureHelpers.completeAfter(() -> FutureHelpers.allOf(writerFutureList), testState.writersListComplete.get(0));
         FutureHelpers.exceptionListener(testState.writersComplete,
                                         t -> log.error("Exception while waiting for writers to complete", t));
 
@@ -297,6 +300,7 @@ abstract class AbstractFailoverTests {
     }
 
     void addNewWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {
+        Preconditions.checkNotNull(testState.writersListComplete.get(1));
         log.info("Client factory details {}", clientFactory.toString());
         log.info("Creating {} writers", writers);
         List<EventStreamWriter<Long>> newlyAddedWriterList = new ArrayList<>();
@@ -315,25 +319,19 @@ abstract class AbstractFailoverTests {
                 newWritersFutureList.add(writerFuture);
             }
         });
-        FutureHelpers.completeAfter(() -> FutureHelpers.allOf(newWritersFutureList), testState.newWritersComplete);
+        FutureHelpers.completeAfter(() -> FutureHelpers.allOf(newWritersFutureList), testState.writersListComplete.get(1));
         FutureHelpers.exceptionListener(testState.writersComplete,
                                         t -> log.error("Exception while waiting for writers to complete", t));
     }
 
-    void stopWriters(boolean stopAdditionalWriters) {
+    void stopWriters() {
         //Stop Writers
         log.info("Stop write flag status {}", testState.stopWriteFlag);
         testState.stopWriteFlag.set(true);
 
         log.info("Wait for writers execution to complete");
-        if (!FutureHelpers.await(testState.writersComplete)) {
+        if (!FutureHelpers.await(FutureHelpers.allOf(testState.writersListComplete))) {
             log.error("Writers stopped with exceptions");
-        }
-
-        if (stopAdditionalWriters) {
-            if (!FutureHelpers.await(testState.newWritersComplete)) {
-                log.error("Writers stopped with exceptions");
-            }
         }
 
         // check for exceptions during writes

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -197,7 +197,7 @@ abstract class AbstractFailoverTests {
                     }
                 } catch (Throwable e) {
                     //TODO: remove it once issue https://github.com/pravega/pravega/issues/1687 is fixed.
-                    if (e.getCause() instanceof RetriesExhaustedException) {
+                    if (e.getCause() instanceof RetriesExhaustedException || e instanceof RetriesExhaustedException) {
                         log.warn("Test exception in reading events: ", e);
                         continue;
                     }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -321,7 +321,7 @@ abstract class AbstractFailoverTests {
                                         t -> log.error("Exception while waiting for writers to complete", t));
     }
 
-    void stopReadersAndWriters(ReaderGroupManager readerGroupManager, String readerGroupName) {
+    void stopWriters(boolean stopAdditionalWriters) {
         //Stop Writers
         log.info("Stop write flag status {}", testState.stopWriteFlag);
         testState.stopWriteFlag.set(true);
@@ -330,17 +330,21 @@ abstract class AbstractFailoverTests {
         if (!FutureHelpers.await(testState.writersComplete)) {
             log.error("Writers stopped with exceptions");
         }
-        if (testState.autoScaleTestFlag.get()) {
+
+        if (stopAdditionalWriters) {
             if (!FutureHelpers.await(testState.newWritersComplete)) {
                 log.error("Writers stopped with exceptions");
             }
         }
+
         // check for exceptions during writes
         if (testState.getWriteException.get() != null) {
             log.info("Unable to write events:", testState.getWriteException.get());
             Assert.fail("Unable to write events. Test failure");
         }
+    }
 
+    void stopReaders(ReaderGroupManager readerGroupManager, String readerGroupName) {
         //Stop Readers
         log.info("Stop read flag status {}", testState.stopReadFlag);
         testState.stopReadFlag.set(true);
@@ -354,7 +358,9 @@ abstract class AbstractFailoverTests {
             log.info("Unable to read events:", testState.getReadException.get());
             Assert.fail("Unable to read events. Test failure");
         }
+    }
 
+    void validateResults(ReaderGroupManager readerGroupManager, String readerGroupName) {
         log.info("All writers and readers have stopped. Event Written Count:{}, Event Read " +
                 "Count: {}", testState.eventWriteCount.get(), testState.eventsReadFromPravega.size());
         assertEquals(testState.eventWriteCount.get(), testState.eventsReadFromPravega.size());

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -83,6 +83,7 @@ abstract class AbstractFailoverTests {
         final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
+        final AtomicBoolean autoScaleTestFlag = new AtomicBoolean(true);
     }
 
     void performFailoverTest() {
@@ -329,8 +330,10 @@ abstract class AbstractFailoverTests {
         if (!FutureHelpers.await(testState.writersComplete)) {
             log.error("Writers stopped with exceptions");
         }
-        if (!FutureHelpers.await(testState.newWritersComplete)) {
-            log.error("Writers stopped with exceptions");
+        if (testState.autoScaleTestFlag.get()) {
+            if (!FutureHelpers.await(testState.newWritersComplete)) {
+                log.error("Writers stopped with exceptions");
+            }
         }
         // check for exceptions during writes
         if (testState.getWriteException.get() != null) {

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.system;
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.system;
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.system;
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -139,7 +139,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
             performFailoverTest();
 
             stopWriters(true);
-            stopReaders(readerGroupManager, readerGroupName);
+            stopReaders();
             validateResults(readerGroupManager, readerGroupName);
 
         }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -94,8 +94,6 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
-        testState.writersListComplete.add(testState.writersComplete);
-        testState.writersListComplete.add(testState.newWritersComplete);
         testState.writersListComplete.set(0, testState.writersComplete);
         testState.writersListComplete.set(1, testState.newWritersComplete);
     }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -94,6 +94,10 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
+        testState.writersListComplete.add(testState.writersComplete);
+        testState.writersListComplete.add(testState.newWritersComplete);
+        testState.writersListComplete.set(0, testState.writersComplete);
+        testState.writersListComplete.set(1, testState.newWritersComplete);
     }
 
     @After
@@ -138,7 +142,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
             //run the failover test after scaling
             performFailoverTest();
 
-            stopWriters(true);
+            stopWriters();
             stopReaders();
             validateResults(readerGroupManager, readerGroupName);
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -94,8 +94,8 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
-        testState.writersListComplete.set(0, testState.writersComplete);
-        testState.writersListComplete.set(1, testState.newWritersComplete);
+        testState.writersListComplete.add(0, testState.writersComplete);
+        testState.writersListComplete.add(1, testState.newWritersComplete);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -138,7 +138,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
             //run the failover test after scaling
             performFailoverTest();
 
-            stopReadersAndWriters(readerGroupManager, readerGroupName);
+            stopWriters(true);
+            stopReaders(readerGroupManager, readerGroupName);
+            validateResults(readerGroupManager, readerGroupName);
 
         }
         cleanUp(scope, AUTO_SCALE_STREAM);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.system;
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -90,11 +90,12 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         assertTrue(segmentStoreInstance.isRunning());
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
 
-        //executor service
-        executorService = Executors.newScheduledThreadPool(NUM_READERS + NUM_WRITERS);
+        //num. of readers + num. of writers + 1 to run checkScale operation
+        executorService = Executors.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1);
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
+        testState.autoScaleTestFlag.set(false);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -164,7 +164,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
             performFailoverTest();
 
             stopWriters(false);
-            stopReaders(readerGroupManager, readerGroupName);
+            stopReaders();
             validateResults(readerGroupManager, readerGroupName);
         }
         cleanUp(scope, SCALE_STREAM);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -95,7 +95,6 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
-        testState.autoScaleTestFlag.set(false);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -95,7 +95,6 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
-        testState.writersListComplete.add(testState.writersComplete);
         testState.writersListComplete.set(0, testState.writersComplete);
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -95,7 +95,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
-        testState.writersListComplete.set(0, testState.writersComplete);
+        testState.writersListComplete.add(0, testState.writersComplete);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -164,7 +164,9 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
             //run the failover test after scaling
             performFailoverTest();
 
-            stopReadersAndWriters(readerGroupManager, readerGroupName);
+            stopWriters(false);
+            stopReaders(readerGroupManager, readerGroupName);
+            validateResults(readerGroupManager, readerGroupName);
         }
         cleanUp(scope, SCALE_STREAM);
         log.info("Test {} succeeds ", "ReadWriteAndScaleWithFailover");

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -95,6 +95,8 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect);
         testState = new TestState();
+        testState.writersListComplete.add(testState.writersComplete);
+        testState.writersListComplete.set(0, testState.writersComplete);
     }
 
     @After
@@ -163,7 +165,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
             //run the failover test after scaling
             performFailoverTest();
 
-            stopWriters(false);
+            stopWriters();
             stopReaders();
             validateResults(readerGroupManager, readerGroupName);
         }


### PR DESCRIPTION

**Change log description**
* Waits until all  futures are added to both `writerFutureList` and `readerFutureList` before processing the `FutureHelpers.completeAfter` statement.

**Purpose of the change**
In the current code, we add elements to both `writerFutureList` and `readerFutureList` asynchronously, so when we invoke `FutureHelpers.allOf`, which itself invokes `Collections.toArray`, we are probably passing an incomplete list as the `runAsync` task is probably still running. Consequently, assuming that this observation is correct, we are not going to wait for all instances we need to.

**What the code does**
Adds a `thenRun` stage to process `completeAfter`only after writers\readers have been created.

**How to verify it**
Need to run the system tests.